### PR TITLE
Prevent 'Script-thrown exception' being the exception message

### DIFF
--- a/src/classes/SFDCAccessControlException.cls
+++ b/src/classes/SFDCAccessControlException.cls
@@ -89,6 +89,7 @@ global with sharing class SFDCAccessControlException extends Exception {
 	 * @param eField The field name this error was triggered on
 	 */
 	global SFDCAccessControlException(String eText, ExceptionType eType, ExceptionReason eReason, String eObject, String eField) {
+		this(eText + ' ' + eType + ' ' + eReason + ' ' + eObject + ' ' + eField);
 		this.eText = eText;
 		this.eType = eType;
 		this.eReason = eReason;


### PR DESCRIPTION
The SFDCAccessControlException wasn't setting the exception message. This resulted in the message being 'Script-thrown exception'.
Explicitly call the Exception constructor to set the message with useful details.